### PR TITLE
Feat/add new dlt resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cd dlt
 ```
 cp .dlt/secrets.example .dlt/secrets.toml
 ```
+- Make sure the file is located in `Renegade/dlt/.dlt/secrets.toml`.
 - Add secrets like aws credentials, nyc open data app token, etc.
 - You can change the `bucket_url` to your local directory for testing purposes. In which case, you don't need to specify the aws credentials.
 - You also don't need to specify the nyn api token for development. You only need it to limit the API call limit.

--- a/README.md
+++ b/README.md
@@ -16,24 +16,13 @@ pip install -r requirements.txt
 cd dlt
 ```
 4. Configure Secrets:
-   - Create a `secrets.toml` file in the `.dlt` directory.
-   - Add the following configuration to the `secrets.toml` file:
-     ```toml
-     # put your secret values and credentials here. do not share this file and do not push it to github
-
-     [destination.filesystem]
-     bucket_url = "s3://proj-renegade" 
-     # for local testing, you can point it to your local directory
-     # bucket_url = "/Users/Yuki/Desktop/Orem Data/Database Tycoon/Renegade/dlt/data"
-
-     [destination.filesystem.credentials]
-     aws_access_key_id = "YOUR_AWS_KEY_ID"
-     aws_secret_access_key = "YOUR_AWS_SECRET_ACCESS_KEY"
-
-     [sources.rest_api]  # optional, passing this will increase the API call limit
-     # if you decide to use the app token, please uncomment the lines 9, 11~13, and 25 in the nyc_open_data_pipeline.py file
-     nyc_open_data_app_token = "YOUR_APP_TOKEN"  # optional
-     ```
+- Create a `secrets.toml` file in the `.dlt` directory.
+```
+cp .dlt/secrets.example .dlt/secrets.toml
+```
+- Add secrets like aws credentials, nyc open data app token, etc.
+- You can change the `bucket_url` to your local directory for testing purposes. In which case, you don't need to specify the aws credentials.
+- You also don't need to specify the nyn api token for development. You only need it to limit the API call limit.
 
 
 5. Run the pipeline. If you want to run it for testing purposes, modify the `maximum_offset` to limit the data for pagination. 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,17 @@ cd dlt
 
      [destination.filesystem]
      bucket_url = "s3://proj-renegade" 
+     # for local testing, you can point it to your local directory
+     # bucket_url = "/Users/Yuki/Desktop/Orem Data/Database Tycoon/Renegade/dlt/data"
 
      [destination.filesystem.credentials]
      aws_access_key_id = "YOUR_AWS_KEY_ID"
      aws_secret_access_key = "YOUR_AWS_SECRET_ACCESS_KEY"
+
+     [sources.rest_api]  # optional, passing this will increase the API call limit
+     # if you decide to use the app token, please uncomment the lines 9, 11~13, and 25 in the nyc_open_data_pipeline.py file
+     nyc_open_data_app_token = "YOUR_APP_TOKEN"  # optional
+     ```
 
 
 5. Run the pipeline. If you want to run it for testing purposes, modify the `maximum_offset` to limit the data for pagination. 

--- a/dlt/.dlt/secrets.example
+++ b/dlt/.dlt/secrets.example
@@ -1,0 +1,11 @@
+[sources.rest_api]
+nyc_open_data_app_token = "YOUR_APP_TOKEN"
+
+[destination.filesystem]
+bucket_url = "s3://proj-renegade" 
+# bucket_url = "OR_YOUR_LOCAL_FILE_PATH"
+
+[destination.filesystem.credentials]
+aws_access_key_id = "YOUR_AWS_ACCESS_KEY_ID"
+aws_secret_access_key = "YOUR_AWS_SECRET_ACCESS_KEY"
+

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -1,22 +1,28 @@
 import dlt
 from dlt.sources.helpers.rest_client import RESTClient
-from dlt.sources.helpers.rest_client.auth import HttpBasicAuth
+from dlt.sources.helpers.rest_client.auth import APIKeyAuth
 from dlt.sources.helpers.rest_client.paginators import OffsetPaginator
 
 
 @dlt.source
-def nyc_open_data_source():
+def nyc_open_data_source(
+    nyc_open_data_app_token=dlt.secrets["sources.rest_api.nyc_open_data_app_token"],
+):
+    auth = APIKeyAuth(
+        name="X-App-Token", api_key=nyc_open_data_app_token, location="header"
+    )
     client = RESTClient(
         base_url="https://data.cityofnewyork.us/resource/",
         paginator=OffsetPaginator(
             limit=1000,  # The maximum number of items to retrieve in each request.
-            # offset=0,  # The initial offset for the first request. Defaults to 0.
+            offset=0,  # The initial offset for the first request. Defaults to 0.
             offset_param="$offset",  # The name of the query parameter used to specify the offset. Defaults to "offset".
             limit_param="$limit",  # The name of the query parameter used to specify the limit. Defaults to "limit".
             total_path=None,  # A JSONPath expression for the total number of items. If not provided, pagination is controlled by maximum_offset and stop_after_empty_page.
             maximum_offset=1000,  # Optional maximum offset value. Limits pagination even without a total count.
             stop_after_empty_page=True,  # Whether pagination should stop when a page contains no result items. Defaults to True.
         ),
+        auth=auth,
     )
 
     @dlt.resource(write_disposition="replace")
@@ -24,7 +30,17 @@ def nyc_open_data_source():
         for page in client.paginate("erm2-nwe9"):
             yield page
 
-    return nyc_311_service_requests
+    @dlt.resource(write_disposition="replace")
+    def hpd_complaints():
+        """
+        The Department of Housing Preservation and Development (HPD) records complaints made by the public
+        for conditions violating the New York City Housing Maintenance Code (HMC)
+        or the New York State Multiple Dwelling Law (MDL).
+        """
+        for page in client.paginate("ygpa-z7cr"):
+            yield page
+
+    return [hpd_complaints]
 
 
 def load_nyc_open_data_source():

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -6,11 +6,11 @@ from dlt.sources.helpers.rest_client.paginators import OffsetPaginator
 
 @dlt.source
 def nyc_open_data_source(
-    nyc_open_data_app_token=dlt.secrets["sources.rest_api.nyc_open_data_app_token"],
+    # nyc_open_data_app_token=dlt.secrets["sources.rest_api.nyc_open_data_app_token"],
 ):
-    auth = APIKeyAuth(
-        name="X-App-Token", api_key=nyc_open_data_app_token, location="header"
-    )
+    # auth = APIKeyAuth(
+    #     name="X-App-Token", api_key=nyc_open_data_app_token, location="header"
+    # )
     client = RESTClient(
         base_url="https://data.cityofnewyork.us/resource/",
         paginator=OffsetPaginator(
@@ -22,7 +22,7 @@ def nyc_open_data_source(
             maximum_offset=1000,  # Optional maximum offset value. Limits pagination even without a total count.
             stop_after_empty_page=True,  # Whether pagination should stop when a page contains no result items. Defaults to True.
         ),
-        auth=auth,
+        # auth=auth,
     )
 
     @dlt.resource(write_disposition="replace")

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -14,12 +14,12 @@ def nyc_open_data_source(
     client = RESTClient(
         base_url="https://data.cityofnewyork.us/resource/",
         paginator=OffsetPaginator(
-            limit=1000,  # The maximum number of items to retrieve in each request.
+            limit=10000,  # The maximum number of items to retrieve in each request.
             offset=0,  # The initial offset for the first request. Defaults to 0.
             offset_param="$offset",  # The name of the query parameter used to specify the offset. Defaults to "offset".
             limit_param="$limit",  # The name of the query parameter used to specify the limit. Defaults to "limit".
             total_path=None,  # A JSONPath expression for the total number of items. If not provided, pagination is controlled by maximum_offset and stop_after_empty_page.
-            maximum_offset=1000,  # Optional maximum offset value. Limits pagination even without a total count.
+            maximum_offset=10000,  # Optional maximum offset value. Limits pagination even without a total count.
             stop_after_empty_page=True,  # Whether pagination should stop when a page contains no result items. Defaults to True.
         ),
         # auth=auth,
@@ -27,6 +27,9 @@ def nyc_open_data_source(
 
     @dlt.resource(write_disposition="replace")
     def nyc_311_service_requests():
+        """
+        This resource is NOT being used currently. 
+        """
         for page in client.paginate("erm2-nwe9"):
             yield page
 


### PR DESCRIPTION
## Changes
- Added a `hpd_complaints` dlt resource (a python function) that pulls data from [Housing Maintenance Code Complaints and Problems](https://dev.socrata.com/foundry/data.cityofnewyork.us/ygpa-z7cr)
- Ingested sample 1000 rows in [the s3 bucket](s3://proj-renegade/nyc_open_data/hpd_complaints/)

## To Do Items
- Ingest the full data (~15M rows)
- Modify the code so that we just ingest data incrementally based on date columns in the dataset