### PR TITLE
Adding incremental load option + iceberg 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ cp .dlt/secrets.example .dlt/secrets.toml
 
 
 5. Run the pipeline. If you want to run it for testing purposes, modify the `maximum_offset` to limit the data for pagination. 
+- By default, the following command will run the pipeline in incremental mode.
 ```
 python nyc_open_data_pipeline.py
+```
+- If you want to run the pipeline in historical mode, to backfill historical data (up to the time of running the command), you can use the following command:
+```
+python nyc_open_data_pipeline.py --backfill
 ```
 6. Check pipeline info:
 ```

--- a/README.md
+++ b/README.md
@@ -3,25 +3,29 @@
 ## Instructions
 
 1. Create a new virtual environment: 
-```
-python -m venv .venv
-source .venv/bin/activate
-```
+
+    ```
+    python -m venv .venv
+    source .venv/bin/activate
+    ```
 2. Install dependencies: 
-```
-pip install -r requirements.txt
-```
+
+    ```
+    pip install -r requirements.txt
+    ```
 **Recommend using a version of python >= 3.8.1 and < 3.13 for compatibility with `dlt[filesystem]==1.5.0`.**  
 
 3. Navigate in to the `dlt` folder:
-```
-cd dlt
-```
+
+    ```
+    cd dlt
+    ```
 4. Configure Secrets:
 - Create a `secrets.toml` file in the `.dlt` directory.
-```
-cp .dlt/secrets.example .dlt/secrets.toml
-```
+
+    ```
+    cp .dlt/secrets.example .dlt/secrets.toml
+    ```
 - Make sure the file is located in `Renegade/dlt/.dlt/secrets.toml`.
 - Add secrets like aws credentials, nyc open data app token, etc.
 - You can change the `bucket_url` to your local directory for testing purposes. In which case, you don't need to specify the aws credentials.
@@ -30,21 +34,23 @@ cp .dlt/secrets.example .dlt/secrets.toml
 
 5. Run the pipeline. If you want to run it for testing purposes, modify the `maximum_offset` to limit the data for pagination. 
 - By default, the following command will run the pipeline in incremental mode.
-```
-python nyc_open_data_pipeline.py
-```
+
+  ```
+  python nyc_open_data_pipeline.py
+  ```
 - If you want to run the pipeline in historical mode, to backfill historical data (up to the time of running the command), you can use the following command:
-```
-python nyc_open_data_pipeline.py --backfill
-```
+    ```
+    python nyc_open_data_pipeline.py --backfill
+    ```
 6. Check pipeline info:
-```
-dlt pipeline nyc_open_data_pipeline info
-``` 
-or 
-```
-dlt pipeline nyc_open_data_pipeline show
-``` 
+
+    ```
+    dlt pipeline nyc_open_data_pipeline info
+    ``` 
+    or 
+    ```
+    dlt pipeline nyc_open_data_pipeline show
+    ``` 
 to use streamlit  
 
 ### Evidence

--- a/dlt/.dlt/secrets.example
+++ b/dlt/.dlt/secrets.example
@@ -2,7 +2,7 @@
 nyc_open_data_app_token = "YOUR_APP_TOKEN"
 
 [destination.filesystem]
-bucket_url = "s3://proj-renegade" 
+bucket_url = "s3://proj-renegade/dlt/landing" 
 # bucket_url = "OR_YOUR_LOCAL_FILE_PATH"
 
 [destination.filesystem.credentials]

--- a/dlt/.dlt/secrets.example
+++ b/dlt/.dlt/secrets.example
@@ -8,4 +8,5 @@ bucket_url = "s3://proj-renegade/dlt/landing"
 [destination.filesystem.credentials]
 aws_access_key_id = "YOUR_AWS_ACCESS_KEY_ID"
 aws_secret_access_key = "YOUR_AWS_SECRET_ACCESS_KEY"
+region_name = "us-east-2"
 

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -77,6 +77,7 @@ def load_nyc_open_data_source(backfill=False):
             layout="{table_name}/historical/loaded_on_{YYYY}_{MM}_{DD}/{load_id}.{file_id}.{ext}"
             if backfill
             else "{table_name}/incremental/{YYYY}/{MM}/{load_id}.{file_id}.{ext}",
+            timezone="America/New_York"  # dataset_timezone
         ),
         dataset_name="nyc_open_data",
         progress="log",

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -38,7 +38,7 @@ def nyc_open_data_source(
         for page in client.paginate("erm2-nwe9"):
             yield page
 
-    @dlt.resource(write_disposition="append")
+    @dlt.resource(write_disposition="append", table_format="iceberg")
     def hpd_complaints():
         """
         The Department of Housing Preservation and Development (HPD) records complaints made by the public
@@ -73,12 +73,7 @@ def nyc_open_data_source(
 def load_nyc_open_data_source(backfill=False):
     pipeline = dlt.pipeline(
         pipeline_name="nyc_open_data_pipeline",
-        destination=filesystem(
-            layout="{table_name}/historical_data_to_{YYYY}_{MM}_{DD}_{load_id}_{file_id}.{ext}"
-            if backfill
-            else "{table_name}/incremental_data_from_{YYYY}_{MM}_01_to_{YYYY}_{MM}_{DD}_{load_id}_{file_id}.{ext}",
-            timezone="America/New_York"  # dataset_timezone
-        ),
+        destination='filesystem'
         dataset_name="nyc_open_data",
         progress="log",
     )

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -74,9 +74,9 @@ def load_nyc_open_data_source(backfill=False):
     pipeline = dlt.pipeline(
         pipeline_name="nyc_open_data_pipeline",
         destination=filesystem(
-            layout="{table_name}/historical/loaded_on_{YYYY}_{MM}_{DD}/{load_id}.{file_id}.{ext}"
+            layout="{table_name}/historical_data_to_{YYYY}_{MM}_{DD}_{load_id}_{file_id}.{ext}"
             if backfill
-            else "{table_name}/incremental/{YYYY}/{MM}/{load_id}.{file_id}.{ext}",
+            else "{table_name}/incremental_data_from_{YYYY}_{MM}_01_to_{YYYY}_{MM}_{DD}_{load_id}_{file_id}.{ext}",
             timezone="America/New_York"  # dataset_timezone
         ),
         dataset_name="nyc_open_data",

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -2,11 +2,16 @@ import dlt
 from dlt.sources.helpers.rest_client import RESTClient
 from dlt.sources.helpers.rest_client.auth import APIKeyAuth
 from dlt.sources.helpers.rest_client.paginators import OffsetPaginator
+from dlt.destinations import filesystem
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import argparse
 
 
 @dlt.source
 def nyc_open_data_source(
     # nyc_open_data_app_token=dlt.secrets["sources.rest_api.nyc_open_data_app_token"],
+    backfill=False,
 ):
     # auth = APIKeyAuth(
     #     name="X-App-Token", api_key=nyc_open_data_app_token, location="header"
@@ -14,12 +19,12 @@ def nyc_open_data_source(
     client = RESTClient(
         base_url="https://data.cityofnewyork.us/resource/",
         paginator=OffsetPaginator(
-            limit=10000,  # The maximum number of items to retrieve in each request.
+            limit=100_000,  # The maximum number of items to retrieve in each request.
             offset=0,  # The initial offset for the first request. Defaults to 0.
             offset_param="$offset",  # The name of the query parameter used to specify the offset. Defaults to "offset".
             limit_param="$limit",  # The name of the query parameter used to specify the limit. Defaults to "limit".
             total_path=None,  # A JSONPath expression for the total number of items. If not provided, pagination is controlled by maximum_offset and stop_after_empty_page.
-            maximum_offset=10000,  # Optional maximum offset value. Limits pagination even without a total count.
+            # maximum_offset=1000,  # Optional maximum offset value. Limits pagination even without a total count.
             stop_after_empty_page=True,  # Whether pagination should stop when a page contains no result items. Defaults to True.
         ),
         # auth=auth,
@@ -33,28 +38,59 @@ def nyc_open_data_source(
         for page in client.paginate("erm2-nwe9"):
             yield page
 
-    @dlt.resource(write_disposition="replace")
+    @dlt.resource(write_disposition="append")
     def hpd_complaints():
         """
         The Department of Housing Preservation and Development (HPD) records complaints made by the public
         for conditions violating the New York City Housing Maintenance Code (HMC)
         or the New York State Multiple Dwelling Law (MDL).
+
+        This resource supports two loading modes:
+        - Incremental: When backfill=False (default), only loads complaints from the current month
+          based on received_date, problem_status_date, or complaint_status_date
+        - Historical: When backfill=True, loads the complete historical dataset
         """
-        for page in client.paginate("ygpa-z7cr"):
+
+        params = {}
+        if not backfill:
+            current_time = datetime.now(ZoneInfo("America/New_York"))
+            current_month = current_time.strftime(
+                "%Y-%m"
+            )  # This will output like "2024-02"
+
+            params["$where"] = (
+                f"date_trunc_ym(received_date) = '{current_month}' or "
+                f"date_trunc_ym(problem_status_date) = '{current_month}' or "
+                f"date_trunc_ym(complaint_status_date) = '{current_month}'"
+            )
+
+        for page in client.paginate("ygpa-z7cr", params=params):
             yield page
 
     return [hpd_complaints]
 
 
-def load_nyc_open_data_source():
+def load_nyc_open_data_source(backfill=False):
     pipeline = dlt.pipeline(
         pipeline_name="nyc_open_data_pipeline",
-        destination="filesystem",
+        destination=filesystem(
+            layout="{table_name}/historical/loaded_on_{YYYY}_{MM}_{DD}/{load_id}.{file_id}.{ext}"
+            if backfill
+            else "{table_name}/incremental/{YYYY}/{MM}/{load_id}.{file_id}.{ext}",
+        ),
         dataset_name="nyc_open_data",
         progress="log",
     )
-    pipeline.run(nyc_open_data_source(), loader_file_format="parquet")
+    pipeline.run(nyc_open_data_source(backfill=backfill), loader_file_format="parquet")
 
 
 if __name__ == "__main__":
-    load_nyc_open_data_source()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Run in backfill mode to load all historical data",
+    )
+    args = parser.parse_args()
+
+    load_nyc_open_data_source(backfill=args.backfill)

--- a/dlt/nyc_open_data_pipeline.py
+++ b/dlt/nyc_open_data_pipeline.py
@@ -73,7 +73,7 @@ def nyc_open_data_source(
 def load_nyc_open_data_source(backfill=False):
     pipeline = dlt.pipeline(
         pipeline_name="nyc_open_data_pipeline",
-        destination='filesystem'
+        destination='filesystem',
         dataset_name="nyc_open_data",
         progress="log",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ comm==0.2.2
 croniter==6.0.0
 dateparser==1.2.0
 decorator==5.1.1
-dlt[filesystem]==1.5.0
+dlt[filesystem,pyiceberg]==1.5.0
 duckdb==1.1.3
 executing==2.1.0
 frozenlist==1.5.0


### PR DESCRIPTION
## Changes 
- Historical / incremental load options via command line argument. 
    - `python run nyc_open_data_pipeline --backfill` to ingest all historical data.
    - `python run nyc_open_data_pipeline --current-month` to ingest records that have been updated or newly added during the current month.
    - `python run nyc_open_data_pipeline --start-date YYYY-MM-DD --end-date YYYY-MM-DD` to ingest records that have been updated or newly added within the specified date range.
- Changed to "Append" mode. 
- Changed file path to `s3://proj-renegade/dlt/landing` from `s3://proj-renegade`
- Changed file/table format to iceberg from parquet. With duckdb, you'll need to provide the file path to the most recent metadata to read data. The below is an example duckdb query in python to read an iceberg table from s3:

  ```python
  import duckdb
  
  query = """
      INSTALL iceberg;
      LOAD iceberg;
      UPDATE EXTENSIONS (iceberg);
      CREATE SECRET IF NOT EXISTS S3_CONFIG (
          TYPE S3,
          KEY_ID 'xxx',
          SECRET 'xxx',
          REGION 'us-east-2' 
      );
      select count(*) from iceberg_scan('s3://proj-renegade/dlt/landing/nyc_open_data/hpd_complaints/metadata/00001-90ac6e4e-93c6-4d55-bc74-8b1b6b21e41a.metadata.json')
  """
  
  rel = duckdb.sql(query)
  
  print(rel)
  
  ```

## Notes
- As we keep appending data, Iceberg adds different matadata files but it's ordered per version like `00001-xxxxxx.metadata.json` and `00002-xxxxxx.metadata.json`. We'll need to have a logic to parse these and get the most recent file (this kind of trivial problem is easily solved by LLMs or an IDE like Cursor). 
- dlt doesn't allow you to use the `merge` operation with the filesystem destination. Thus sticking to `append`. The use of `delta` table format allows you to use `merge`, but not with iceberg yet. 

## About [The New Dataset](https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Complaints-and-Problems/ygpa-z7cr/about_data)
- `problem_id` is the unique key in this [Housing Maintenance Code Complaints and Problems dataset](https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Complaints-and-Problems/ygpa-z7cr/about_data). However, there are a few duplicated records even on this key. This just seems like small errors or bad quality management on the source side. This needs to be handled downstream in sqlmesh. 
- There is no true `last_updated_date` in the dataset, though there are `received_date`, `complaint_status_date`, and `problem_status_date`. And there is no clear or consistent way to determine the most recent date in any of the records. I'd suggest to add/use something like `last_updated_date` by taking the max of all these three date columns (which I'm essentially doing to only ingest new and updated records. Also I could've done this in dlt, but I think it's better to keep the source data as is)

## To Dos
- Add a daily/monthly data ingestion job configued via github actions (when the time comes)
- Add a deduplication and merge process downstream to
    - remove duplicates on `problem_id` primary/unique key
    - merge records on `problem_id` to keep the most up-to-date records 
