### PR TITLE
[do not merge] Attempt to update Cube config for Starburst

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - CUBEJS_DB_PASS=${STARBURST_CLUSTER_PASSWORD}
       - CUBEJS_DB_PRESTO_CATALOG=dbtycoon_renegade
       - CUBEJS_DB_NAME=dbt
-      - CUBEJS_DEV_MODE=true
 
   evidence:
     image: evidencedev/devenv:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,13 @@ services:
       - ./cube/model:/cube/model
       - ./data:/data
     environment:
+      - CUBEJS_DB_TYPE=trino
+      - CUBEJS_DB_HOST=databasetycoon.galaxy.starburst.io
+      - CUBEJS_DB_USER=stephen@databasetycoon.com
+      - CUBEJS_DB_PASS=XJM7qap9rhe@dmd4xaz
+      - CUBEJS_DB_PRESTO_CATALOG=dbtycoon_renegade
+      - CUBEJS_DB_SCHEMA=nyc_open_data
       - CUBEJS_DEV_MODE=true
-      - CUBEJS_DB_TYPE=duckdb
-      - CUBEJS_SCHEMA_PATH=/cube/model
-      - CUBEJS_DB_DUCKDB_DATABASE_PATH=/data/nycdata.db # moved to dedicated data directory
 
   evidence:
     image: evidencedev/devenv:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,14 @@ services:
       - 15432:15432
     volumes:
       - .:/cube/conf
-      - ./cube/model:/cube/model
-      - ./data:/data
     environment:
+      - CUBEJS_DEV_MODE=true
       - CUBEJS_DB_TYPE=trino
-      - CUBEJS_DB_HOST=databasetycoon.galaxy.starburst.io
-      - CUBEJS_DB_USER=stephen@databasetycoon.com
-      - CUBEJS_DB_PASS=XJM7qap9rhe@dmd4xaz
+      - CUBEJS_DB_HOST=databasetycoon-free-cluster.trino.galaxy.starburst.io
+      - CUBEJS_DB_USER=stephen@databasetycoon.com/accountadmin
+      - CUBEJS_DB_PASS=${STARBURST_CLUSTER_PASSWORD}
       - CUBEJS_DB_PRESTO_CATALOG=dbtycoon_renegade
-      - CUBEJS_DB_SCHEMA=nyc_open_data
+      - CUBEJS_DB_NAME=dbt
       - CUBEJS_DEV_MODE=true
 
   evidence:
@@ -28,7 +27,6 @@ services:
       - NODE_ENV=development
     depends_on:
       - cube
-
 networks:
   default:
     name: renegade-network 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - CUBEJS_DEV_MODE=true
       - CUBEJS_DB_TYPE=trino
       - CUBEJS_DB_HOST=databasetycoon-free-cluster.trino.galaxy.starburst.io
-      - CUBEJS_DB_USER=stephen@databasetycoon.com/accountadmin
+      - CUBEJS_DB_USER=${STARBURST_CLUSTER_PARTNER_CONNECT_USER}
       - CUBEJS_DB_PASS=${STARBURST_CLUSTER_PASSWORD}
       - CUBEJS_DB_PRESTO_CATALOG=dbtycoon_renegade
       - CUBEJS_DB_NAME=dbt


### PR DESCRIPTION
I am trying to replace our duckdb refs to point to Starburst for the Cube setup. To test this, make sure your `.env` file does contain the cluster password.

According to [Cube docs](https://cube.dev/docs/product/configuration/data-sources/trino), there are new variables needed. The connection details come from Starburst’s Partner Connect connection strings.

The config on this branch is not able to connect to Starburst and view the catalog:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/ff24c8a6-f91e-4cf7-8ad2-eff5fe7d4133" />

When you spin up Cube, you can force the connection wizard screen by navigating to: [http://localhost:4000/#/connection](http://localhost:4000/#/connection)
This screen has no Trino icon. I tested the Presto connection but I’m not sure if it fails because it’s not interchangeable or because there is a connection issue. ([Related issue in Cube repo](https://github.com/cube-js/cube/issues/8349))