### PR TITLE
Add HPD visuals in Evidence

### DIFF
--- a/evidence/pages/hpd_problem_buildings.md
+++ b/evidence/pages/hpd_problem_buildings.md
@@ -1,0 +1,122 @@
+# HPD Problem Buildings Exploration
+
+The City of New York makes available [data surrounding complaints made to the Department of Housing Preservation and Development (HPD)](
+https://data.cityofnewyork.us/Housing-Development/Housing-Maintenance-Code-Complaints-and-Problems/ygpa-z7cr/about_data). Using this dataset, let's explore buildings in each borough with a high incidence of complaints. This dataset contains records from ~2003 to 2025.
+
+## Overall Dataset, 2020-2025
+
+### Problem Categories, Severity, and Seasonality
+```hpd_overall_categories
+select date_trunc('quarter', (received_month || '-01')::date) as quarter, major_category, sum(problem_count) as problem_count 
+from nycdata.hpd_problem_categories
+group by 1, 2
+order by 1, 3
+```
+
+Looking at the overall data, these are the most common categories of problems reported:
+<BarChart 
+    data={hpd_overall_categories}
+    x=quarter
+    y=problem_count
+    series=major_category
+    title="Problem Counts by Category, Last 5 years"
+/>  
+
+**Heating/Hot Water** is the most common problem category overall, and clearly peaks in the colder months. **Unsanitary Condition** is the second most common category.
+
+```hpd_overall_types
+select date_trunc('quarter', (received_month || '-01')::date) as quarter, type, sum(problem_count) as problem_count 
+from nycdata.hpd_problem_categories
+group by 1, 2
+order by 1, 3
+```
+
+These problems are also reported at varying severities:
+<LineChart 
+    data={hpd_overall_types}
+    x=quarter
+    y=problem_count
+    series=type
+    title="Problem Counts by Type, Last 5 years"
+/>
+The seasonality is very clear here.
+
+```hpd_overall_dimensions
+select date_trunc('quarter', (received_month || '-01')::date) as quarter, major_category, minor_category, type, space_type, borough, problem_count 
+from nycdata.hpd_problem_categories
+```
+
+
+## Problem Buildings
+
+In each borough, let's explore the top-ranked buildings by count of problem calls where the severity is emergency:
+```top_5_problem_buildings
+select *, building_address || ' (' || building_id || ')' as building_id_address from nycdata.hpd_top_5_emergency_problem_buildings
+```
+<BarChart 
+    data={top_5_problem_buildings}
+    x=building_id_address
+    y=total_emergency_problems
+    series=borough
+    title="Emergency Problems, Top 5 Buildings per Borough, All Time"
+    swapXY=true
+/>
+
+By default, I'm including all of the top 25 problem buildings in the charts below, but we can also filter on individual buildings. The building_ids are the values in parentheses above.
+
+```sql building_ids
+select building_id from nycdata.hpd_top_5_emergency_problem_buildings
+```
+<Dropdown
+    name=selected_building
+    data={building_ids}
+    value=building_id
+>
+    <DropdownOption value="%" valueLabel="All Buildings"/>
+</Dropdown>
+
+
+```sql top_buildings_counts_over_time
+select
+    year
+    , building_address
+    , sum(problem_count) as problem_count
+from nycdata.hpd_top_5_building_problems_yearly
+where building_id like '${inputs.selected_building.value}'
+group by 1, 2
+```
+
+### Problem Reports Over Time
+
+Are these buildings consistently high in problem count over time?
+<LineChart 
+    data={top_buildings_counts_over_time}
+    x=year
+    y=problem_count
+    series=building_address
+    title="Count of Emergency Problems Annually by Building"
+/>
+
+### Resolution Times
+```sql resolution_times
+select * from nycdata.hpd_problem_resolution_times
+where building_id like '${inputs.selected_building.value}'
+```
+<DataTable data={resolution_times}/>
+
+## Appendix
+
+### Counts by Dimension
+
+<DimensionGrid
+     data={hpd_overall_dimensions}
+     metric='sum(problem_count)'
+     name=selected_dimensions
+/> 
+<LineChart
+     data={hpd_overall_dimensions}
+     x=quarter
+     handleMissing=zero
+     title="Problem Count by Selected Dimensions"
+/>
+

--- a/evidence/pages/hpd_problem_buildings.md
+++ b/evidence/pages/hpd_problem_buildings.md
@@ -102,7 +102,13 @@ Are these buildings consistently high in problem count over time?
 select * from nycdata.hpd_problem_resolution_times
 where building_id like '${inputs.selected_building.value}'
 ```
-<DataTable data={resolution_times}/>
+<LineChart 
+    data={resolution_times}
+    x=year
+    y=median_days_to_resolution
+    series=building_address
+    title="Median Days to Complaint Closure"
+/>
 
 ## Appendix
 

--- a/evidence/pages/nycdata.md
+++ b/evidence/pages/nycdata.md
@@ -91,4 +91,4 @@ group by 1, 2
     series=agency
     xAxisTitle='Month by Request Creation Date'
     yAxisTitle='Count of Requests'
-/>
+/> 

--- a/evidence/sources/nycdata/aggregated__agencies.sql
+++ b/evidence/sources/nycdata/aggregated__agencies.sql
@@ -1,1 +1,2 @@
-select * from service_requests_agencies;
+select agency, agency_name, total_requests 
+from dbtycoon_renegade.dbt.aggregated__agencies

--- a/evidence/sources/nycdata/aggregated__monthly_requests_type.sql
+++ b/evidence/sources/nycdata/aggregated__monthly_requests_type.sql
@@ -1,1 +1,10 @@
-select * from service_requests;
+select
+  format_datetime(request_month, 'yyyy-MM') as request_month
+  , agency
+  , city_or_borough
+  , complaint_type
+  , total_requests
+  , total_closed_requests
+  , total_unresolved_requests 
+
+from dbtycoon_renegade.dbt.aggregated__service_requests

--- a/evidence/sources/nycdata/hpd_problem_categories.sql
+++ b/evidence/sources/nycdata/hpd_problem_categories.sql
@@ -1,0 +1,15 @@
+select
+    format_datetime(received_date, 'yyyy-MM') as received_month
+    , major_category
+    , minor_category
+    , space_type
+    , unit_type
+    , type
+    , borough
+    , complaint_anonymous_flag
+    , count(*) as problem_count
+
+from nyc_open_data.hpd_complaints
+where received_date >= current_date - interval '5' year
+group by 1, 2, 3, 4, 5, 6, 7, 8
+order by 1

--- a/evidence/sources/nycdata/hpd_problem_resolution_times.sql
+++ b/evidence/sources/nycdata/hpd_problem_resolution_times.sql
@@ -2,15 +2,14 @@ with resolution_times as (
 
 select 
     building_id
-    , date_trunc('quarter', received_date) as quarter
-    , house_number || street_name as building_address
+    , extract(year from received_date) as year
+    , house_number || ' ' || street_name as building_address
     , date_diff('day', received_date, complaint_status_date) as days_to_resolution
 
 from nyc_open_data.hpd_complaints
 where
     complaint_status = 'CLOSE'
     and type != 'NON EMERGENCY'
-    and received_date >= current_date - interval '5' year
     and building_id in (
     '811407'
     , '428710'
@@ -35,10 +34,11 @@ where
 )
 
 select
-    building_id
+    year
+    , building_id
     , building_address
     , max(days_to_resolution) as max_days_to_resolution
     , approx_percentile(days_to_resolution, 0.5) as median_days_to_resolution
 
 from resolution_times
-group by 1, 2
+group by 1, 2, 3

--- a/evidence/sources/nycdata/hpd_problem_resolution_times.sql
+++ b/evidence/sources/nycdata/hpd_problem_resolution_times.sql
@@ -1,0 +1,44 @@
+with resolution_times as (
+
+select 
+    building_id
+    , date_trunc('quarter', received_date) as quarter
+    , house_number || street_name as building_address
+    , date_diff('day', received_date, complaint_status_date) as days_to_resolution
+
+from nyc_open_data.hpd_complaints
+where
+    complaint_status = 'CLOSE'
+    and type != 'NON EMERGENCY'
+    and received_date >= current_date - interval '5' year
+    and building_id in (
+    '811407'
+    , '428710'
+    , '411605'
+    , '706059'
+    , '661708'
+    , '6131'
+    , '13120'
+    , '28340'
+    , '27337'
+    , '9051'
+    , '114412'
+    , '125695'
+    , '51000'
+    , '81982'
+    , '65175'
+    , '370489'
+    , '294912'
+    , '808361'
+    , '313392'
+    )
+)
+
+select
+    building_id
+    , building_address
+    , max(days_to_resolution) as max_days_to_resolution
+    , approx_percentile(days_to_resolution, 0.5) as median_days_to_resolution
+
+from resolution_times
+group by 1, 2

--- a/evidence/sources/nycdata/hpd_top_5_building_problems_yearly.sql
+++ b/evidence/sources/nycdata/hpd_top_5_building_problems_yearly.sql
@@ -1,0 +1,32 @@
+select
+    extract(year from received_date) as year
+    , building_id
+    , borough
+    , house_number || ' ' || street_name as building_address
+    , count(*) as problem_count
+
+from nyc_open_data.hpd_complaints
+where
+    building_id in (
+    '811407'
+    , '428710'
+    , '411605'
+    , '706059'
+    , '661708'
+    , '6131'
+    , '13120'
+    , '28340'
+    , '27337'
+    , '9051'
+    , '114412'
+    , '125695'
+    , '51000'
+    , '81982'
+    , '65175'
+    , '370489'
+    , '294912'
+    , '808361'
+    , '313392'
+)
+    and type != 'NON EMERGENCY'
+group by 1, 2, 3, 4

--- a/evidence/sources/nycdata/hpd_top_5_emergency_problem_buildings.sql
+++ b/evidence/sources/nycdata/hpd_top_5_emergency_problem_buildings.sql
@@ -1,0 +1,16 @@
+with by_borough as (
+
+    select
+        borough
+        , building_id
+        , house_number || ' ' || street_name as building_address
+        , count(distinct problem_id) as total_emergency_problems
+        , rank() over (partition by borough order by count(*) desc) as ranking
+
+    from nyc_open_data.hpd_complaints 
+    where type != 'NON EMERGENCY'
+    group by 1, 2, 3
+
+) 
+
+select * from by_borough where ranking < 6


### PR DESCRIPTION
This PR primarily adds Evidence-related source queries and visuals for the HPD dataset.

There are a lot of opportunities for improvement/refactoring especially around the source queries, but encountered an unexpected issue where [our dbt staging model for HPD](https://github.com/Database-Tycoon/Renegade/blob/main/dbt/models/staging/nyc_hpd/stg__housing_maintenance_code_complaints_and_problems.sql) doesn’t contain the full dataset, so building on this right now will just add to my problems. Once this is resolved, we can create some models that centralize this logic instead of doing it all from scratch in each Evidence source query.

There is also an issue with dates in the dbt models - for 311 dataset also, the `request_month` field is causing a casting error when running source in Evidence. Same issue exists for `received_date` in HPD.

**I didn’t commit an updated `connections.yaml` for Evidence because the Starburst configs feel more sensitive than duckdb** but this is needed to run Evidence.